### PR TITLE
theta1 less and greater done properly and exact=TRUE, computeZ=TRUE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,29 +5,29 @@ Version: 0.8.6
 Authors@R: c(
   person("Rosanne", "Turner", email = "rosanne.turner@cwi.nl",
   role = "aut"),
-  person("Alexander", "Ly", email = "a.ly@jasp-stats.org", 
+  person("Alexander", "Ly", email = "a.ly@jasp-stats.org",
   role = c("cre", "aut")),
-  person("Muriel", "Perez", email = "Muriel.Perez@cwi.nl", 
+  person("Muriel Felipe", "Pérez-Ortiz", email = "Muriel.Perez@cwi.nl",
   role = c("ctb")),
-  person("Judith", "ter Schure", email = "Judith.ter.Schure@cwi.nl", 
+  person("Judith", "ter Schure", email = "Judith.ter.Schure@cwi.nl",
   role = c("ctb")),
-  person("Peter", "Grunwald", email = "Peter.Grunwald@cwi.nl", 
+  person("Peter", "Grunwald", email = "Peter.Grunwald@cwi.nl",
   role = c("ctb"))
   )
 Maintainer: Alexander Ly <a.ly@jasp-stats.org>
-Description: Functions to design and apply tests that are anytime valid. The 
-  functions can be used to design hypothesis tests in the prospective/randomised 
-  control trial setting or in the observational/retrospective setting. The 
-  resulting tests remain valid under both optional stopping and optional 
-  continuation. The current version includes safe t-tests and safe tests of 
-  two proportions. For details on the theory of safe tests, see 
+Description: Functions to design and apply tests that are anytime valid. The
+  functions can be used to design hypothesis tests in the prospective/randomised
+  control trial setting or in the observational/retrospective setting. The
+  resulting tests remain valid under both optional stopping and optional
+  continuation. The current version includes safe t-tests and safe tests of
+  two proportions. For details on the theory of safe tests, see
   Grunwald, de Heide and Koolen (2019) "Safe Testing". <arXiv:1906.07801>.
 License: LGPL (>= 3)
 Encoding: UTF-8
 LazyData: true
 Depends:
   R (>= 3.6)
-Imports: 
+Imports:
   stats (>= 3.6),
   hypergeo (>= 1.2-13),
   purrr (>= 0.3.3),

--- a/R/safeS3Methods.R
+++ b/R/safeS3Methods.R
@@ -116,9 +116,10 @@ print.safeTest <- function (x, digits = getOption("digits"), prefix = "\t",
   eThresholdString <- format(1/designObj[["alpha"]], digits = max(1L, digits - 2L))
 
   out <- character()
-  if (!is.null(statValue)) {
+
+  if (!is.null(statValue))
     out <- c(out, paste(names(statValue), "=", format(statValue, digits = max(1L, digits - 2L))))
-  }
+
   out <- c(out, paste(names(parameter), "=", format(parameter, digits = max(1L, digits - 2L))))
   cat(paste0("test: ", paste(out, collapse = ", "), sep="\n"))
   cat("e-value =", eValueString, "> 1/alpha =", eThresholdString, ":",

--- a/man/safeLogrankTest.Rd
+++ b/man/safeLogrankTest.Rd
@@ -13,7 +13,8 @@ safeLogrankTest(
   survTime = NULL,
   group = NULL,
   pilot = FALSE,
-  exact = FALSE,
+  exact = TRUE,
+  computeZ = TRUE,
   ...
 )
 
@@ -22,7 +23,6 @@ safeLogrankTestStat(
   nEvents,
   designObj,
   ciValue = 0.95,
-  alternative = c("two.sided", "greater", "less"),
   dataNull = 1,
   sigma = 1
 )
@@ -49,16 +49,17 @@ samples is exactly as planned. The default null h0=1 is used, alpha=0.05, and al
 To change these default values, please use \code{\link{designSafeLogrank}}.}
 
 \item{exact}{a logical indicating whether the exact safe logrank test needs to be performed based on
-the hypergeometric likelihood}
+the hypergeometric likelihood. Default is \code{TRUE}, if \code{FALSE} then the safe z-test (for Gaussian data)
+applied to the logrank z-statistic is used instead.}
+
+\item{computeZ}{logical. If \code{TRUE} computes the logrank z-statistic.
+Default is \code{TRUE}.}
 
 \item{...}{further arguments to be passed to or from methods.}
 
 \item{z}{numeric representing the observed z statistic.}
 
 \item{nEvents}{numeric > 0, observed number of events.}
-
-\item{alternative}{a character string specifying the alternative hypothesis must be one of "two.sided" (default),
-"greater" or "less".}
 
 \item{dataNull}{numeric > 0, the null hypothesis corresponding to the z statistics.
 By default dataNull = 1 representing}
@@ -72,7 +73,7 @@ following components:
 \describe{
   \item{statistic}{the value of the summary, i.e., z-statistic or the e-value.}
   \item{nEvents}{The number of observed events.}
-  \item{eValue}{the s-value of the safe test.}
+  \item{eValue}{the e-value of the safe test.}
   \item{confSeq}{An anytime-valid confidence sequence.}
   \item{estimate}{To be implemented: An estimate of the hazard ratio.}
   \item{testType}{"logrank".}
@@ -175,10 +176,10 @@ for (i in 1:4) {
                             event = dataSoFar$status,
                             type = "counting")
 
-  interimResult <- safeLogrankTest(survObj ~ dataSoFar$group, designObj = designObj)
-  interimResult
+  interimResult <- safeLogrankTest(survObj ~ dataSoFar$group,
+                                   designObj = designObj, exact=FALSE)
 
-# Compare logrank score to calculations by hand
+  # Compare logrank score to calculations by hand
   localTest <- round(interimResult$statistic - handResult[i], 7) == 0
 
   if (!localTest)


### PR DESCRIPTION
1. For exact always theta1 < 1, if not then theta1 <- 1/theta1 so less/greater is always the correct. Note only works for h0=1 2. (1) safeLogrankTest: computeZ=TRUE argument, (2) designSafeLogrank, saves ratio, (3) print.safeTest: is.null(statistic) then not shown, (4) Muriel's name set safeLogrankTest exact=TRUE by default 3. safeLogrankTestStat now takes alternative from the designObj as should and s-value to e-value in the description.