### PR TITLE
Update logRankTest.R

### DIFF
--- a/R/logRankTest.R
+++ b/R/logRankTest.R
@@ -274,9 +274,10 @@ safeLogrankTest <- function(formula, designObj=NULL, ciValue=NULL, data=NULL, su
     nEff <- ratio/(1+ratio)^2*nEvents
 
     zStat <- sumStats[["z"]]
-    meanObs <- zStat/sqrt(nEff)
-
-    result <- list("statistic"=zStat, "n"=nEvents, "estimate"=exp(meanObs), "eValue"=NULL,
+    sumOMinE <- sumStats[["sumOMinE"]]
+    sumVarOMinE <- sumStats[["sumVarOMinE"]]
+    
+    result <- list("statistic"=zStat, "n"=nEvents, "estimate"=exp(sumOMinE/sumVarOMinE), "eValue"=NULL,
                    "confSeq"=NULL, "testType"="gLogrank", "dataName"=dataName)
     class(result) <- "safeTest"
 


### PR DESCRIPTION
exp(sumOMinE/sumVarOMinE) is the Peto estimator and is slightly different from what was implemented before. Could you please give this estimate some attribute that notifies the user that this is the Peto estimator? Maybe also add the reference to R Documentation description of the function, that is: the Statistical Appendix of this paper: Yusuf, S., Peto, R., Lewis, J., Collins, R., & Sleight, P. (1985). Beta blockade during and after myocardial infarction: an overview of the randomized trials. Progress in cardiovascular diseases, 27(5), 335-371.