### PR TITLE
fix checkAndReturnsNPlan

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -182,7 +182,7 @@ checkAndReturnsNPlan <- function(nPlan, ratio=1, testType=c("oneSample", "paired
     nPlan <- c(nPlan, ratio*nPlan)
     warning('testType=="twoSample" specified, but nPlan[2] not provided. nPlan[2] = ratio*nPlan[1], that is, ',
             nPlan[2], '.')
-  } else if (testType=="paired" && length(nPlan==1)) {
+  } else if (testType=="paired" && length(nPlan)==1) {
     nPlan <- c(nPlan, nPlan)
     warning('testType=="paired" specified, but nPlan[2] not provided. nPlan[2] set to nPlan[1].')
   } else if (testType=="oneSample" && length(nPlan)==2) {


### PR DESCRIPTION
The following incorrectly gave an error:

```
designObj <- designSafeT(deltaMin=0.5, alpha=0.05, nPlan=c(40, 40),
                         alternative="greater", testType="paired", 
                         seed=1, pb=FALSE)
```